### PR TITLE
Move the downward API directory to '/etc/podnetinfo'

### DIFF
--- a/client-image/client.yaml
+++ b/client-image/client.yaml
@@ -13,8 +13,8 @@ spec:
         readOnly: false
       - name: log
         mountPath: /var/log
-      - name: podinfo
-        mountPath: /etc/podinfo
+      - name: podnetinfo
+        mountPath: /etc/podnetinfo
     command: ["sleep", "infinity"]
   volumes:
     - name: vhostsock
@@ -23,7 +23,7 @@ spec:
     - name: log
       hostPath:
         path: /var/log
-    - name: podinfo
+    - name: podnetinfo
       downwardAPI:
         items:
           - path: "annotations"

--- a/deployment/k8s-pre-1-16/sriovdp-vdpa-daemonset.yaml
+++ b/deployment/k8s-pre-1-16/sriovdp-vdpa-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: bmcfall/sriov-device-plugin:0.1.4
+        image: nfvpe/sriov-device-plugin:latest
         imagePullPolicy: Never
         args:
         - --log-dir=sriovdp

--- a/deployment/k8s-pre-1-16/vdpa-daemonset.yaml
+++ b/deployment/k8s-pre-1-16/vdpa-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: vdpadpdk-daemonset
-        image: bmcfall/vdpa-daemonset:0.1.4
+        image: vdpa-daemonset:latest
         imagePullPolicy: Never
         securityContext:
           privileged: true
@@ -38,7 +38,7 @@ spec:
             hugepages-1Gi: 2Gi
         #command: ["sleep", "infinity"]
       - name: vdpa-grpc-server
-        image: bmcfall/vdpa-grpc-server:0.1.4
+        image: vdpa-grpc-server:latest
         imagePullPolicy: Never
         securityContext:
           privileged: true

--- a/deployment/scylla-pod.yaml
+++ b/deployment/scylla-pod.yaml
@@ -37,15 +37,15 @@ spec:
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podinfo
-      name: podinfo
+    - mountPath: /etc/podnetinfo
+      name: podnetinfo
       readOnly: false
     - mountPath: /var/lib/cni/usrspcni/
       name: shared-dir
     - mountPath: /var/run/scylla/
       name: shared-scylla-dir
   volumes:
-  - name: podinfo
+  - name: podnetinfo
     downwardAPI:
       items:
         - path: "labels"

--- a/deployment/seastar-httpd-pod.yaml
+++ b/deployment/seastar-httpd-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: seastar-httpd
-    image: bmcfall/seastar-httpd:0.1.5
+    image: seastar-httpd:latest
     imagePullPolicy: Never
     securityContext:
       privileged: true
@@ -43,13 +43,13 @@ spec:
     #command: ["sleep", "infinity"]
   initContainers:
   - name: httpd-init-container
-    image: bmcfall/httpd-init-container:0.1.4
+    image: httpd-init-container:latest
     imagePullPolicy: Never
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podinfo
-      name: podinfo
+    - mountPath: /etc/podnetinfo
+      name: podnetinfo
       readOnly: false
     - mountPath: /var/lib/cni/usrspcni/
       name: shared-dir
@@ -57,7 +57,7 @@ spec:
       name: shared-seastar-dir
     #command: ["sleep", "infinity"]
   volumes:
-  - name: podinfo
+  - name: podnetinfo
     downwardAPI:
       items:
         - path: "labels"

--- a/deployment/seastar-seawreck-pod.yaml
+++ b/deployment/seastar-seawreck-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: seastar-seawreck
-    image: bmcfall/seastar-httpd:0.1.5
+    image: seastar-httpd:latest
     imagePullPolicy: Never
     securityContext:
       privileged: true
@@ -43,13 +43,13 @@ spec:
     #command: ["sleep", "infinity"]
   initContainers:
   - name: httpd-init-container
-    image: bmcfall/httpd-init-container:0.1.4
+    image: httpd-init-container:latest
     imagePullPolicy: Never
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podinfo
-      name: podinfo
+    - mountPath: /etc/podnetinfo
+      name: podnetinfo
       readOnly: false
     - mountPath: /var/lib/cni/usrspcni/
       name: shared-dir
@@ -57,7 +57,7 @@ spec:
       name: shared-seastar-dir
     #command: ["sleep", "infinity"]
   volumes:
-  - name: podinfo
+  - name: podnetinfo
     downwardAPI:
       items:
         - path: "labels"

--- a/deployment/sriovdp-vdpa-daemonset.yaml
+++ b/deployment/sriovdp-vdpa-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: bmcfall/sriov-device-plugin:0.1.4
+        image: nfvpe/sriov-device-plugin:latest
         imagePullPolicy: Never
         args:
         - --log-dir=sriovdp

--- a/deployment/vdpa-daemonset.yaml
+++ b/deployment/vdpa-daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: vdpadpdk-daemonset
-        image: bmcfall/vdpa-daemonset:0.1.4
+        image: vdpa-daemonset:latest
         imagePullPolicy: Never
         startupProbe:
           failureThreshold: 30
@@ -46,7 +46,7 @@ spec:
             hugepages-2Mi: 2048Mi
         #command: ["sleep", "infinity"]
       - name: vdpa-grpc-server
-        image: bmcfall/vdpa-grpc-server:0.1.4
+        image: vdpa-grpc-server:latest
         imagePullPolicy: Never
         startupProbe:
           failureThreshold: 30

--- a/deployment/vdpa-pod-1.yaml
+++ b/deployment/vdpa-pod-1.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   containers:
   - name: vdpa-example
-    image: bmcfall/dpdk-app-centos:0.1.4
+    image: dpdk-app-centos:latest
     imagePullPolicy: Never
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podinfo
-      name: podinfo
+    - mountPath: /etc/podnetinfo
+      name: podnetinfo
       readOnly: false
     - mountPath: /var/lib/cni/usrspcni/
       name: shared-dir
@@ -41,7 +41,7 @@ spec:
     # DPDK command line options.
     #command: ["sleep", "infinity"]
   volumes:
-  - name: podinfo
+  - name: podnetinfo
     downwardAPI:
       items:
         - path: "labels"

--- a/dpdk-app-centos/Dockerfile
+++ b/dpdk-app-centos/Dockerfile
@@ -22,8 +22,6 @@ RUN yum install -y wget numactl-devel git golang make; yum clean all
 WORKDIR /root/go/src/
 RUN go get github.com/openshift/app-netutil 2>&1 > /tmp/UserspaceDockerBuild.log || echo "Can ignore no GO files."
 WORKDIR /root/go/src/github.com/openshift/app-netutil
-# Lock down code to commit on 10/22/2019
-RUN git checkout 156a6eab4812fbfaa3173ace626a453b440da7db
 RUN make c_sample
 RUN cp bin/libnetutil_api.so /lib64/libnetutil_api.so; cp bin/libnetutil_api.h /usr/include/libnetutil_api.h
 

--- a/server-image/server.yaml
+++ b/server-image/server.yaml
@@ -13,8 +13,8 @@ spec:
         readOnly: false
       - name: log
         mountPath: /var/log
-      - name: podinfo
-        mountPath: /etc/podinfo
+      - name: podnetinfo
+        mountPath: /etc/podnetinfo
     #command: ["sleep", "infinity"]
   volumes:
     - name: vhostsock
@@ -23,7 +23,7 @@ spec:
     - name: log
       hostPath:
         path: /var/log
-    - name: podinfo
+    - name: podnetinfo
       downwardAPI:
         items:
           - path: "annotations"


### PR DESCRIPTION
app-netutil move the downward API directory to '/etc/podnetinfo' to
match SR-IOV admission controller value. Make the same change to this
repo.

Also moved all the podspecs back to using the latest locally built
image. This was locked to a fixed version DockerHub version in a
previous merge to lock down images for KubeCon Demo.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>